### PR TITLE
Enables use of config with --config; Fixes name collision from local and S3 files

### DIFF
--- a/conf/local.config
+++ b/conf/local.config
@@ -1,0 +1,4 @@
+executor {
+    name = 'local'
+    queueSize = 1
+    }

--- a/conf/processA_cpus_4.config
+++ b/conf/processA_cpus_4.config
@@ -1,3 +1,5 @@
+// Selectively overwrite the nextflow.config params in the current config for few params
+// All other params will inherit the values defined in nextflow.config
 params {
     processA_cpus = 4
 }

--- a/conf/processA_cpus_4.config
+++ b/conf/processA_cpus_4.config
@@ -1,0 +1,7 @@
+params {
+    processA_cpus = 4
+}
+
+executor {
+    name = 'local'
+}

--- a/conf/processA_cpus_4.config
+++ b/conf/processA_cpus_4.config
@@ -1,9 +1,8 @@
 // Selectively overwrite the nextflow.config params in the current config for few params
 // All other params will inherit the values defined in nextflow.config
+// Define only parameters in the parameter scope, do not add other scopes as these are parameterised in nextflow.config
+
 params {
     processA_cpus = 4
-}
-
-executor {
-    name = 'local'
+    executor = 'local'
 }

--- a/conf/standard.config
+++ b/conf/standard.config
@@ -1,1 +1,1 @@
-// This is a reserved config file please do not edit!
+// This is a reserved config file and must stay empty, please do not edit!

--- a/conf/standard.config
+++ b/conf/standard.config
@@ -1,0 +1,1 @@
+// This is a reserved config file please do not edit!

--- a/main.nf
+++ b/main.nf
@@ -1,3 +1,27 @@
+// Header log info
+log.info "\nPARAMETERS SUMMARY"
+log.info "config                                : ${params.config}"
+log.info "s3Location                            : ${params.s3Location}"
+log.info "fileSuffix                            : ${params.fileSuffix}"
+log.info "repsProcessA                          : ${params.repsProcessA}"
+log.info "processAWriteToDiskMb                 : ${params.processAWriteToDiskMb}"
+log.info "processATimeRange                     : ${params.processATimeRange}"
+log.info "filesProcessA                         : ${params.filesProcessA}"
+log.info "processATimeBetweenFileCreationInSecs : ${params.processATimeBetweenFileCreationInSecs}"
+log.info "processBTimeRange                     : ${params.processBTimeRange}"
+log.info "processBWriteToDiskMb                 : ${params.processBWriteToDiskMb}"
+log.info "processCTimeRange                     : ${params.processCTimeRange}"
+log.info "processDTimeRange                     : ${params.processDTimeRange}"
+log.info "output                                : ${params.output}"
+log.info "echo                                  : ${params.echo}"
+log.info "cpus                                  : ${params.cpus}"
+log.info "processA_cpus                         : ${params.processA_cpus}"
+log.info "errorStrategy                         : ${params.errorStrategy}"
+log.info "container                             : ${params.container}"
+log.info "maxForks                              : ${params.maxForks}"
+log.info "queueSize                             : ${params.queueSize}"
+log.info "executor                              : ${params.executor}"
+log.info ""
 
 numberRepetitionsForProcessA = params.repsProcessA
 numberFilesForProcessA = params.filesProcessA
@@ -7,7 +31,7 @@ processAS3InputFiles = Channel.fromPath("${params.s3Location}/*${params.fileSuff
 
 process processA {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
-  	tag "$s3_file"
+	tag "cpus: ${task.cpus}, s3 file: ${s3_file}"
 
 	input:
 	val x from processAInput
@@ -22,9 +46,10 @@ process processA {
 	script:
 	"""
 	# Simulate the time the processes takes to finish
+	pwd=`basename \${PWD}`
 	timeToWait=\$(shuf -i ${params.processATimeRange} -n 1)
 	for i in {1..${numberFilesForProcessA}};
-	do echo test > file_\${i}.txt
+	do echo test > "\${pwd}"_file_\${i}.txt
 	sleep ${params.processATimeBetweenFileCreationInSecs}
 	done;
 	sleep \$timeToWait

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,8 +23,8 @@ params {
 	cpus = 1
 	processA_cpus = 1
 	errorStrategy = 'ignore'
-    container = 'quay.io/lifebitai/ubuntu:18.10'
-    maxForks = 200
+	 container = 'quay.io/lifebitai/ubuntu:18.10'
+	 maxForks = 200	    maxForks = 200
 	
 	queueSize = 200
 	executor = 'ignite'

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
 	output = "results"
 
 	echo = false
-	 cpus = 1
+	cpus = 1
 	processA_cpus = 1
 	errorStrategy = 'ignore'
     container = 'quay.io/lifebitai/ubuntu:18.10'

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,7 @@
 docker.enabled = true
 
 params {
+	config = 'conf/standard.config'
 	s3Location = 's3://lifebit-featured-datasets/pipelines/spammer-nf/input_files'
 	fileSuffix = ''
 	repsProcessA = 10
@@ -17,11 +18,11 @@ params {
 	output = "results"
 	
 	echo = false
-        cpus = 1
+    cpus = 1
 	processA_cpus = 1
 	errorStrategy = 'ignore'
-        container = 'quay.io/lifebitai/ubuntu:18.10'
-        maxForks = 200
+    container = 'quay.io/lifebitai/ubuntu:18.10'
+    maxForks = 200
 	
 	queueSize = 200
 	executor = 'ignite'	
@@ -36,10 +37,15 @@ process {
 
     withName: processA {
 	cpus = params.processA_cpus
-	}
+		}
     }
 
 executor {
     name = params.executor
     queueSize = params.queueSize
     }
+
+
+profiles {
+	standard { includeConfig params.config }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,5 +1,7 @@
 docker.enabled = true
 
+// NOTE: 
+// Initialise the values of the params to the preferred default value or to false
 params {
 	config = 'conf/standard.config'
 	s3Location = 's3://lifebit-featured-datasets/pipelines/spammer-nf/input_files'
@@ -16,18 +18,27 @@ params {
 	processCTimeRange = "2-3"
 	processDTimeRange = "2-3"
 	output = "results"
-	
+
 	echo = false
-    cpus = 1
+    cpus = false
 	processA_cpus = 1
 	errorStrategy = 'ignore'
     container = 'quay.io/lifebitai/ubuntu:18.10'
     maxForks = 200
 	
 	queueSize = 200
-	executor = 'ignite'	
+	executor = 'ignite'
     }
 
+// Do not update the order because the values set in params scope will not be overwritten
+// Do not attempt to simplify to 
+// includeConfig params.config 
+// outside of profiles scope, it will fail to update the values of the params
+profiles {
+	standard {includeConfig params.config}
+}
+
+// Do not change order of block, must follow after profiles scope (last section that updates params)
 process {
     echo = params.echo
     cpus = params.cpus
@@ -44,8 +55,3 @@ executor {
     name = params.executor
     queueSize = params.queueSize
     }
-
-
-profiles {
-	standard { includeConfig params.config }
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
 	output = "results"
 
 	echo = false
-    cpus = false
+	 cpus = 1
 	processA_cpus = 1
 	errorStrategy = 'ignore'
     container = 'quay.io/lifebitai/ubuntu:18.10'

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ process {
 
     withName: processA {
 	cpus = params.processA_cpus
-		}
+	}
     }
 
 executor {

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,7 @@ params {
 	processA_cpus = 1
 	errorStrategy = 'ignore'
 	 container = 'quay.io/lifebitai/ubuntu:18.10'
-	 maxForks = 200	    maxForks = 200
+	 maxForks = 200
 	
 	queueSize = 200
 	executor = 'ignite'


### PR DESCRIPTION
This PR:

- Enables the use of a config in a hacky way
By passing the config as `--config` taking advantage of profiles, to be able to use configs in CloudOS

- Fixes name collision issue with files generated and files staged from S3 bucket with similar name
By making the local files using using the task workdir hash in their basename.

- Adds head with log.info to be able to verify evaluated param value in a glance

