### PR TITLE
feat: extended script to configurable parameter for processAWriteToDiskMb

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -74,7 +74,7 @@ process processA {
 	echo \$pwd
 	timeToWait=\$(shuf -i ${params.processATimeRange} -n 1)
 	for i in {1..${numberFilesForProcessA}};
-	do head -c ${processAWriteToDiskMb}MB /dev/urandom > > "\${pwd}"_file_\${i}.txt
+	do head -c ${processAWriteToDiskMb}MB /dev/urandom > "\${pwd}"_file_\${i}.txt
 	sleep ${params.processATimeBetweenFileCreationInSecs}
 	done;
 	sleep \$timeToWait

--- a/main.nf
+++ b/main.nf
@@ -74,7 +74,7 @@ process processA {
 	echo \$pwd
 	timeToWait=\$(shuf -i ${params.processATimeRange} -n 1)
 	for i in {1..${numberFilesForProcessA}};
-	do echo test > "\${pwd}"_file_\${i}.txt
+	do head -c ${processAWriteToDiskMb}MB /dev/urandom > > "\${pwd}"_file_\${i}.txt
 	sleep ${params.processATimeBetweenFileCreationInSecs}
 	done;
 	sleep \$timeToWait

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,7 +11,7 @@ params {
 	dataLocation = 's3://lifebit-featured-datasets/pipelines/spammer-nf/input_files'
 	fileSuffix = ''
 	repsProcessA = 2
-	processAWriteToDiskMb = 10
+	processAWriteToDiskMb = 1
 	processATimeRange = "1-2"
 	filesProcessA = 1
 	processATimeBetweenFileCreationInSecs = 0


### PR DESCRIPTION
Noticed that this parameter is not being used `processAWriteToDiskMb`. Extended the process to use it and decreased defaults a bit.