### PR TITLE
Adds azure profile and config

### DIFF
--- a/conf/azure.config
+++ b/conf/azure.config
@@ -1,0 +1,19 @@
+params {
+    autopool_auto_scale = true
+    autopool_instance_type = 'Standard_D4s_v3'
+    autopool_vm_count = 1
+    autopool_max_vm_count = 50
+}
+
+azure {
+    batch {
+        pools {
+            auto {
+                autoScale = params.autopool_auto_scale
+                vmType = params.autopool_instance_type
+                vmCount = params.autopool_vm_count
+                maxVmCount = params.autopool_max_vm_count
+            }
+        }
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,6 +57,7 @@ params {
 // outside of profiles scope, it will fail to update the values of the params
 profiles {
 	standard {includeConfig params.config}
+	azure {includeConfig 'conf/azure.config'}
 }
 
 // Do not change order of block, must follow after profiles scope (last section that updates params)


### PR DESCRIPTION
Purpose: to add a config that allows user to change the defaults of azure executor on CLoudOS. By default jobs will run with an autopool with 1 dedicated node [Standard_D4_v3](https://azureprice.net/vm/Standard_D4_v3) (4 CPUs, 16 GB RAM) without autoscaling.

Now with this config and exposed parameters user can configure:
- node type
- autoscaling true/false
- target number of VMs (virtual machines, nodes)
- max number of VMs

To test use profile `azure`, optionally change the instance type, but make sure it is a one that workspace batch account has quota for (Azure is very restrictive on quotas by default)

Tested successfully:
https://dev.sdlc.lifebit.ai/app/jobs/649f44a6a5b38a77b7296c74
(Public link: https://dev.sdlc.lifebit.ai/public/jobs/649f44a6a5b38a77b7296c74)

![image](https://github.com/lifebit-ai/spammer-nf/assets/64809705/4edac12c-feda-4e36-a7eb-e3135d1873c0)
![image](https://github.com/lifebit-ai/spammer-nf/assets/64809705/0eace2b3-d924-4389-9497-06946f037184)

![image](https://github.com/lifebit-ai/spammer-nf/assets/64809705/e2a42c85-8a1c-45b9-9917-19fe8c645526)
![image](https://github.com/lifebit-ai/spammer-nf/assets/64809705/96b8df3e-bc9f-4157-9673-80a7d1737180)

