### PR TITLE
fix: child processes cache issue due to same input value

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -61,9 +61,9 @@ process processA {
 	file(a_file) from processAInputFiles
 
 	output:
-    set val(x), val(a_file.name) into processAOutput
-	set val(x), val(a_file.name) into processCInput
-	set val(x), val(a_file.name) into processDInput
+    tuple val(x), val(a_file.name) into processAOutput
+	tuple val(x), val(a_file.name) into processCInput
+	tuple val(x), val(a_file.name) into processDInput
 	file "*.txt"
 
 	script:

--- a/main.nf
+++ b/main.nf
@@ -85,9 +85,9 @@ process processA {
 
 process processB {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
-	input:
-	val x from processAOutput
 
+	input:
+	tuple val(x), val(filename) from processAOutput
 
 	"""
 	${params.pre_script}
@@ -101,8 +101,9 @@ process processB {
 
 process processC {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
+
 	input: 
-	val x from processCInput
+	tuple val(x), val(filename) from processCInput
 
 	"""
 	${params.pre_script}
@@ -116,8 +117,9 @@ process processC {
 
 process processD {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
+
 	input: 
-	val x from processDInput
+	tuple val(x), val(filename) from processDInput
 
 	"""
 	${params.pre_script}

--- a/main.nf
+++ b/main.nf
@@ -49,7 +49,7 @@ log.info ""
 numberRepetitionsForProcessA = params.repsProcessA
 numberFilesForProcessA = params.filesProcessA
 processAWriteToDiskMb = params.processAWriteToDiskMb
-processAInput = Channel.from(1..numberRepetitionsForProcessA)
+processAInput = Channel.from([1] * numberRepetitionsForProcessA)
 processAInputFiles = Channel.fromPath("${params.dataLocation}/*${params.fileSuffix}").take( numberRepetitionsForProcessA )
 
 process processA {

--- a/main.nf
+++ b/main.nf
@@ -49,7 +49,7 @@ log.info ""
 numberRepetitionsForProcessA = params.repsProcessA
 numberFilesForProcessA = params.filesProcessA
 processAWriteToDiskMb = params.processAWriteToDiskMb
-processAInput = Channel.from([1] * numberRepetitionsForProcessA)
+processAInput = Channel.from(1..numberRepetitionsForProcessA)
 processAInputFiles = Channel.fromPath("${params.dataLocation}/*${params.fileSuffix}").take( numberRepetitionsForProcessA )
 
 process processA {

--- a/main.nf
+++ b/main.nf
@@ -61,9 +61,9 @@ process processA {
 	file(a_file) from processAInputFiles
 
 	output:
-	val x into processAOutput
-	val x into processCInput
-	val x into processDInput
+    set val(x), val(a_file.name) into processAOutput
+	set val(x), val(a_file.name) into processCInput
+	set val(x), val(a_file.name) into processDInput
 	file "*.txt"
 
 	script:


### PR DESCRIPTION
### Implementation
This pull request updates the input handling and output structure for `processA` in the `main.nf` Nextflow pipeline. The main improvements are in how input channels are generated and how outputs are structured for downstream processes.
- This changes is essential to avoid caching issue/generating same work directory due to repeated same value.

**Channel and I/O improvements:**

* The `processAInput` channel is now created using a range (`1..numberRepetitionsForProcessA`) instead of a repeated list, simplifying the input sequence.
* The outputs of `processA` now emit tuples containing both the value and the input file name, and the corresponding inputs for `processB`, `processC`, and `processD` are updated to expect these tuples.
* The input declarations for `processB`, `processC`, and `processD` are modified to accept a tuple of value and filename, ensuring all downstream processes receive the required information


**Related tickets:**

- https://lifebit.atlassian.net/browse/LP-69612?focusedCommentId=224420
- https://lifebit.atlassian.net/browse/INTHSM-17413?focusedCommentId=224462


### Testing

**CloudOS Testing**
- https://dev.sdlc.lifebit.ai/app/advanced-analytics/analyses/69525ea9e15a3f0f0171dfd7
- https://dev.sdlc.lifebit.ai/app/advanced-analytics/analyses/695270d861fbbf4b97fafff9 (with 20 additional tasks per processes)
- https://dev.sdlc.lifebit.ai/app/advanced-analytics/analyses/69527266e15a3f0f01720f3b (with 20 additional tasks per processes)

**After fix**
<img width="890" height="316" alt="image" src="https://github.com/user-attachments/assets/9518ec6e-66cc-4a9e-9deb-78d370427e7e" />

each tasks in process Uses different hash
<img width="1313" height="128" alt="image" src="https://github.com/user-attachments/assets/59f09244-1fb8-4368-970d-26123ea6bf93" />

**Before fix**
all tasks in process has same hash
<img width="1227" height="121" alt="image" src="https://github.com/user-attachments/assets/9e2a5293-255e-4f79-b73c-c003e0519cb1" />
