### PR TITLE
fix: processA tag with params prefix for cloud storage

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -54,7 +54,7 @@ processAInputFiles = Channel.fromPath("${params.dataLocation}/*${params.fileSuff
 
 process processA {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
-	tag "cpus: ${task.cpus}, cloud storage: ${cloud_storage_file}"
+	tag "cpus: ${task.cpus}, cloud storage: ${params.cloud_storage_file}"
 
 	input:
 	val x from processAInput


### PR DESCRIPTION
This pull request makes a minor update to the `processA` process in `main.nf`. The change ensures that the tag uses the correct parameter for the cloud storage file, improving consistency and correctness.

* Updated the tag in the `processA` process to reference `params.cloud_storage_file` instead of the local variable `cloud_storage_file`.