### PR TITLE
fix: processA tag with params prefix for cloud storage

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -53,7 +53,7 @@ processAWriteToDiskMb = params.processAWriteToDiskMb
 
 process processA {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
-	tag "cpus: ${task.cpus}, cloud storage: ${cloud_storage_file}"
+	tag "cpus: ${task.cpus}, cloud storage: ${params.cloud_storage_file}"
 
 	input:
 	val x


### PR DESCRIPTION

This pull request makes a minor update to the `processA` definition in `main.nf`, replacing a variable reference with a parameter reference to improve clarity and correctness.

* Updated the `tag` line in `processA` to reference `params.cloud_storage_file` instead of the local variable `cloud_storage_file`, ensuring consistent use of parameters throughout the process definition.


Before fix:
<img width="1884" height="644" alt="image" src="https://github.com/user-attachments/assets/3716e887-b6a8-48a2-a1c8-86788a326c35" />
