### PR TITLE
fix: input files with glob pattern

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -50,7 +50,12 @@ numberRepetitionsForProcessA = params.repsProcessA
 numberFilesForProcessA = params.filesProcessA
 processAWriteToDiskMb = params.processAWriteToDiskMb
 processAInput = Channel.from([1] * numberRepetitionsForProcessA)
-processAInputFiles = Channel.fromPath("${params.dataLocation}/*${params.fileSuffix}").take( numberRepetitionsForProcessA )
+
+def pattern = params.dataLocation.endsWith('/*')
+  ? "${params.dataLocation}${params.fileSuffix ?: ''}"
+  : "${params.dataLocation}/*${params.fileSuffix ?: ''}"
+
+processAInputFiles = Channel.fromPath(pattern, checkIfExists: true).take( numberRepetitionsForProcessA )
 
 process processA {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'


### PR DESCRIPTION
This pull request updates the file pattern logic for loading input files in `main.nf`, making the code more robust and flexible. The main change is to ensure that the file path pattern is constructed correctly based on whether `params.dataLocation` already ends with `/*`, and to add file existence checking.

Improvements to input file handling:

* Added logic to dynamically construct the file matching pattern for `processAInputFiles`, handling cases where `params.dataLocation` may or may not end with `/*`.
* Enabled file existence checking in `Channel.fromPath` by setting `checkIfExists: true`, which improves error handling and robustness.


### Testing
**Ends with `input_files/`**
<img width="1184" height="628" alt="image" src="https://github.com/user-attachments/assets/bb90aa76-d53b-441a-b60d-fd6153c7051d" />


**Ends with `input_files/*`**
<img width="1243" height="609" alt="image" src="https://github.com/user-attachments/assets/ea4cdb2a-9220-4a76-9469-69a5628e1811" />

**Ends with `input_files`**

<img width="1167" height="584" alt="image" src="https://github.com/user-attachments/assets/27091b12-e025-4ba4-91e1-5e9d76b44b9b" />



### Before fix
<img width="1274" height="647" alt="image" src="https://github.com/user-attachments/assets/b4b603be-c7c0-48ee-91e3-ce6de6fe44c4" />
