### PR TITLE
fix: input files with glob pattern

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -130,10 +130,16 @@ process processD {
 
 workflow {
 	processAInput = Channel.from([1] * numberRepetitionsForProcessA)
-	processAInputFiles = Channel.fromPath("${params.dataLocation}/*${params.fileSuffix}").take( numberRepetitionsForProcessA )
+
+  def pattern = params.dataLocation.endsWith('/*')
+    ? "${params.dataLocation}${params.fileSuffix ?: ''}"
+    : "${params.dataLocation}/*${params.fileSuffix ?: ''}"
+
+  processAInputFiles = Channel.fromPath(pattern, checkIfExists: true).take( numberRepetitionsForProcessA )
 
 	processA(processAInput, processAInputFiles)
 	processB(processA.out.processAOutput)
 	processC(processA.out.processCInput)
 	processD(processA.out.processDInput)
 }
+


### PR DESCRIPTION
This pull request updates the way input file patterns are generated for the `processAInputFiles` channel in the `main.nf` workflow. The change improves flexibility and robustness when specifying file locations and suffixes.

Input file pattern handling:

* Added logic to dynamically construct the file pattern for `Channel.fromPath` based on whether `params.dataLocation` already ends with `/*`, ensuring correct handling of file suffixes and preventing duplicate wildcards.
* Enabled the `checkIfExists: true` option for `Channel.fromPath`, which adds validation that the specified files actually exist before proceeding.

### Testing
**ends with `input_files/*`**
<img width="1195" height="615" alt="image" src="https://github.com/user-attachments/assets/b0008250-dffd-485a-859a-b3d69cdfcda0" />

**ends with `input_files/`**
<img width="1195" height="615" alt="image" src="https://github.com/user-attachments/assets/fb3c4b42-cf13-4e28-b6db-4fd30447d2f7" />

**ends with `input_files`**
<img width="1050" height="642" alt="image" src="https://github.com/user-attachments/assets/66d0668c-c840-46c3-9176-6f1ae0f36937" />

#### Before fix
<img width="1213" height="631" alt="image" src="https://github.com/user-attachments/assets/624a42c3-a0d3-493f-8b38-5c63c31d513f" />
