### PR TITLE
feat: migrate from dsl1 from dsl2 mode

### DIFF
--- a/bin/sample.sh
+++ b/bin/sample.sh
@@ -1,0 +1,1 @@
+echo "test"

--- a/main.nf
+++ b/main.nf
@@ -130,10 +130,16 @@ process processD {
 
 workflow {
 	processAInput = Channel.from([1] * numberRepetitionsForProcessA)
-	processAInputFiles = Channel.fromPath("${params.dataLocation}/*${params.fileSuffix}").take( numberRepetitionsForProcessA )
+
+  def pattern = params.dataLocation.endsWith('/*')
+    ? "${params.dataLocation}${params.fileSuffix ?: ''}"
+    : "${params.dataLocation}/*${params.fileSuffix ?: ''}"
+
+  processAInputFiles = Channel.fromPath(pattern, checkIfExists: true).take( numberRepetitionsForProcessA )
 
 	processA(processAInput, processAInputFiles)
 	processB(processA.out.processAOutput)
 	processC(processA.out.processCInput)
 	processD(processA.out.processDInput)
 }
+

--- a/main.nf
+++ b/main.nf
@@ -53,7 +53,7 @@ processAWriteToDiskMb = params.processAWriteToDiskMb
 
 process processA {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
-	tag "cpus: ${task.cpus}, cloud storage: ${cloud_storage_file}"
+	tag "cpus: ${task.cpus}, cloud storage: ${params.cloud_storage_file}"
 
 	input:
 	val x

--- a/main.nf
+++ b/main.nf
@@ -60,9 +60,9 @@ process processA {
 	path a_file
 
 	output:
-	val x, emit: processAOutput
-	val x, emit: processCInput
-	val x, emit: processDInput
+    tuple val(x), val(a_file.name), emit: processAOutput
+	tuple val(x), val(a_file.name), emit: processCInput
+	tuple val(x), val(a_file.name), emit: processDInput
 	file "*.txt"
 
 	script:
@@ -85,7 +85,7 @@ process processA {
 process processB {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
 	input:
-	val x
+	tuple val(x), val(filename)
 
 
 	"""
@@ -101,7 +101,7 @@ process processB {
 process processC {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
 	input: 
-	val x
+	tuple val(x), val(filename)
 
 	"""
 	${params.pre_script}
@@ -116,7 +116,7 @@ process processC {
 process processD {
 	publishDir "${params.output}/${task.hash}", mode: 'copy'
 	input: 
-	val x
+	tuple val(x), val(filename)
 
 	"""
 	${params.pre_script}

--- a/main.nf
+++ b/main.nf
@@ -60,7 +60,7 @@ process processA {
 	path a_file
 
 	output:
-  tuple val(x), val(a_file.name), emit: processAOutput
+	tuple val(x), val(a_file.name), emit: processAOutput
 	tuple val(x), val(a_file.name), emit: processCInput
 	tuple val(x), val(a_file.name), emit: processDInput
 	file "*.txt"


### PR DESCRIPTION
This pull request refactors the workflow definition in `main.nf` to improve clarity and modularity. The main changes involve moving channel initialization and process chaining into a dedicated `workflow` block, and updating input/output handling for processes to use Nextflow's emit syntax and direct channel passing.

Workflow refactoring and modularization:

* Added a `workflow` block to explicitly define channel initialization (`processAInput`, `processAInputFiles`) and process chaining, making the workflow structure clearer and easier to maintain.

Channel and input/output handling improvements:

* Updated process input definitions (`processA`, `processB`, `processC`, `processD`) to accept channels directly, removing inline channel creation and enabling more modular process composition. [[1]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L52-R65) [[2]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L93-R89) [[3]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L109-R104) [[4]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L125-R119)
* Modified process output definitions to use the `emit` keyword, which provides named outputs for easier downstream channel referencing.

Parameter usage corrections:

* Fixed the use of the `cloud_storage_file` parameter in the `tag` definition for `processA`, ensuring the correct value is used from `params`.

These changes make the workflow more modular and maintainable, and align with Nextflow's best practices for channel and process management.